### PR TITLE
bin/test: test ShellCheck, Rubocop by default

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+echo -e "\n=== ShellCheck"
+file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
+    xargs -r shellcheck
+
+echo -e "\n=== RuboCop"
+rubocop -A
+
 echo -e "\n=== RSpec"
 rspec


### PR DESCRIPTION
Watch out for `-A` switch! It's usually useful, but sometimes wrong!

cc @StephenAbbott 