### PR TITLE
bin: don't auto-correct RuboCop

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,7 +6,7 @@ file --mime-type ./* bin/* | grep 'text/x-shellscript' | cut -d':' -f1 |
     xargs -r shellcheck
 
 echo -e "\n=== RuboCop"
-rubocop -A
+rubocop
 
 echo -e "\n=== RSpec"
 rspec


### PR DESCRIPTION
On reflection, I've changed my mind about this.