### PR TITLE
[LEI-4] bin: move migrate-lei to transformers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-oc.git
-  revision: 04ef5f2991164717d90f9f0499d082c296335e89
+  revision: cd92a7b7d1170328236a1b72e4a1ce053a5f47d0
   specs:
     register_sources_oc (0.1.0)
       activesupport (>= 6, < 8)

--- a/bin/migrate-lei
+++ b/bin/migrate-lei
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+
+require 'register_sources_bods/services/migrator_lei'
+
+migrator = RegisterSourcesBods::Services::MigratorLEI.new
+migrator.migrate


### PR DESCRIPTION
If `bin/migrate-lei` were run from sources-bods, various environment variables would have to be set each time. These would correspond to the environment variables already set in transformer-dk, transformer-psc, transformer-sk. Instead, move the script to each transformer, meaning it can be run without extra setup. This should also help to minimise mistakes caused by mistakenly running against the wrong Elasticsearch indexes.

https://github.com/openownership/register-sources-oc/issues/14