### PR TITLE
[#188] fix Config::Adapters incorrect require

### DIFF
--- a/lib/register_transformer_psc/config/adapters.rb
+++ b/lib/register_transformer_psc/config/adapters.rb
@@ -2,7 +2,7 @@
 
 require 'register_common/adapters/s3_adapter'
 
-require 'settings'
+require_relative 'settings'
 
 module RegisterTransformerPsc
   module Config


### PR DESCRIPTION
This was broken in 642b882c88b860cb571ce9f735ad1fd9b2bb571e during the refactor.

---

References https://github.com/openownership/register/issues/188 .