### PR TITLE
[#252] define Procfile, failing at present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-bods.git
-  revision: a5652477180ccbbcbedcdcda2c67ea2351e9a85e
+  revision: 597d75ba6728e621562dd8a96d231902debb72cc
   specs:
     register_sources_bods (0.1.0)
       activesupport (>= 6, < 8)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bin/transform-stream-tmp-fail


### PR DESCRIPTION
This will be activated when we're ready to go live. Meanwhile, it allows Heroku to be set up correctly.

References https://github.com/openownership/register/issues/252 .